### PR TITLE
Update expansion panel readonly flag to 'win' over any other option

### DIFF
--- a/preset/overrides.scss
+++ b/preset/overrides.scss
@@ -39,8 +39,8 @@
     }
   }
 
-  .v-expansion-panel, .v-expansion-panel--readonly .v-expansion-panel-header .v-expansion-panel-header__icon .v-icon {
-    color: map-get($grey, 'lighten1');
+  .v-expansion-panel--readonly > .v-expansion-panel-header > .v-expansion-panel-header__icon > .v-icon {
+    color: map-get($grey, 'lighten1') !important;
   }
 
   .v-skeleton-loader__sidenav, .v-skeleton-loader__menu-item, .v-skeleton-loader__subnav, .v-skeleton-loader__subnav-item, .v-skeleton-loader__action-items {


### PR DESCRIPTION
On development, it would work without the 'important' but once packaged and deployed on staging/prod, a different selector is winning. We can't have that