### PR TITLE
Update v alerts to match storypark colour

### DIFF
--- a/preset/colors/green.scss
+++ b/preset/colors/green.scss
@@ -1,11 +1,11 @@
 $green: (
-  'base': #7FC489,
-  'lighten1': #A2D992,
-  'lighten2': #BEBEEA,
-  'lighten3': #D0F4B6,
-  'lighten4': #DEF9CE,
-  'darken1': #3D8977,
-  'darken2': #0D5E58,
+  'base': #7fc489,
+  'lighten1': #a2d992,
+  'lighten2': #bae59a,
+  'lighten3': #d0f4b6,
+  'lighten4': #def9ce,
+  'darken1': #3d8977,
+  'darken2': #0d5e58,
 );
 
 :export {

--- a/preset/colors/index.scss
+++ b/preset/colors/index.scss
@@ -1,11 +1,11 @@
-@import './green.scss';
-@import './grey.scss';
-@import './orange.scss';
-@import './purple.scss';
-@import './red.scss';
-@import './teal.scss';
-@import './text.scss';
-@import './yellow.scss';
+@import "./green";
+@import "./grey";
+@import "./orange";
+@import "./purple";
+@import "./red";
+@import "./teal";
+@import "./text";
+@import "./yellow";
 
 :export {
   @each $key, $value in $green {

--- a/preset/colors/red.scss
+++ b/preset/colors/red.scss
@@ -1,11 +1,11 @@
 $red: (
-  'base': #F8546E,
-  'lighten1': #FF8798,
-  'lighten2': #FFF099,
-  'lighten3': #FFC4CD,
-  'lighten4': #F9D6DF,
-  'darken1': #E63A5C,
-  'darken2': #D31C4B,
+  'base': #f8546e,
+  'lighten1': #ff8798,
+  'lighten2': #ffacb9,
+  'lighten3': #ffc4cd,
+  'lighten4': #f9d6df,
+  'darken1': #e63a5c,
+  'darken2': #d31c4b,
 );
 
 :export {

--- a/preset/colors/teal.scss
+++ b/preset/colors/teal.scss
@@ -1,10 +1,10 @@
 $teal: (
-  'base': #00B2D0,
-  'lighten1': #93D4E5,
-  'lighten2': #B8E4F2,
-  'lighten3': #D2F1FA,
-  'lighten4': #E8F9FF,
-  'darken1': #0084A5,
+  'base': #00b2d0,
+  'lighten1': #93d4e5,
+  'lighten2': #b8e4f2,
+  'lighten3': #d2f1fa,
+  'lighten4': #e8f9ff,
+  'darken1': #0084a5,
   'darken2': #075476
 );
 

--- a/preset/colors/text.scss
+++ b/preset/colors/text.scss
@@ -1,3 +1,3 @@
-$text-primary-color: #384450;
+$textPrimaryColor: #384450;
 
-:export { textPrimary: $text-primary-color };
+:export { textPrimary: $textPrimaryColor };

--- a/preset/colors/text.scss
+++ b/preset/colors/text.scss
@@ -1,3 +1,3 @@
-$textPrimaryColor: #384450;
+$text-primary-color: #384450;
 
-:export { textPrimary: $textPrimaryColor };
+:export { textPrimary: $text-primary-color };

--- a/preset/colors/text.scss
+++ b/preset/colors/text.scss
@@ -1,3 +1,3 @@
 $text-primary-color: #384450;
 
-:export { textPrimary: $text-primary-color };
+:export { textPrimary: $text-primary-color; };

--- a/preset/colors/yellow.scss
+++ b/preset/colors/yellow.scss
@@ -1,11 +1,11 @@
 $yellow: (
-  'base': #FFD55B,
-  'lighten1': #FFE579,
-  'lighten2': #FFF099,
-  'lighten3': #FFF5B8,
-  'lighten4': #FFFAD6,
-  'darken1': #EDB846,
-  'darken2': #D39C29,
+  'base': #ffd55b,
+  'lighten1': #ffe579,
+  'lighten2': #fff099,
+  'lighten3': #fff5b8,
+  'lighten4': #fffad6,
+  'darken1': #edb846,
+  'darken2': #d39c29,
 );
 
 :export {

--- a/preset/overrides.scss
+++ b/preset/overrides.scss
@@ -36,8 +36,8 @@
     text-transform: none;
 
     &--active {
-      color: $textPrimaryColor;
-      font-weight: map-get($fontWeights, "bold");
+      color: $text-primary-color;
+      font-weight: map-get($font-weights, "bold");
     }
   }
 }

--- a/preset/overrides.scss
+++ b/preset/overrides.scss
@@ -1,12 +1,13 @@
-@import "./variables.scss";
-@import "./expansion_panel_overrides.scss";
-@import "./skeleton_overrides.scss";
+@import "./variables";
+@import "./expansion_panel_overrides";
+@import "./skeleton_overrides";
 
 .v-application--is-ltr {
   .v-list-group--sub-group {
     .v-list-group__header {
       padding-left: 16px;
     }
+
     .v-list-group__items .v-list-item {
       padding-left: 16px;
     }
@@ -18,6 +19,7 @@
     .v-list-group__header {
       padding-right: 16px;
     }
+
     .v-list-group__items .v-list-item {
       padding-right: 16px;
     }
@@ -33,8 +35,8 @@
     text-transform: none;
 
     &--active {
-      font-weight: map-get($font-weights, "bold");
-      color: $text-primary-color;
+      color: $textPrimaryColor;
+      font-weight: map-get($fontWeights, "bold");
     }
   }
 }

--- a/preset/overrides.scss
+++ b/preset/overrides.scss
@@ -1,6 +1,7 @@
 @import "./variables";
 @import "./expansion_panel_overrides";
 @import "./skeleton_overrides";
+@import "./v_alert_overrides";
 
 .v-application--is-ltr {
   .v-list-group--sub-group {

--- a/preset/v_alert_overrides.scss
+++ b/preset/v_alert_overrides.scss
@@ -1,0 +1,35 @@
+.v-application {
+  .v-alert {
+    &--outlined {
+      border: 1px solid !important;
+    }
+
+    &.success,
+    &.success--text {
+      background-color: map-get($green, "lighten4") !important;
+      border-color: map-get($green, "lighten2") !important;
+      color: map-get($green, "darken1") !important;
+    }
+
+    &.info,
+    &.info--text {
+      background-color: map-get($teal, "lighten3") !important;
+      border-color: map-get($teal, "lighten2") !important;
+      color: map-get($teal, "darken1") !important;
+    }
+
+    &.warning,
+    &.warning--text {
+      background-color: map-get($yellow, "lighten4") !important;
+      border-color: map-get($yellow, "lighten1") !important;
+      color: map-get($yellow, "darken1") !important;
+    }
+
+    &.error,
+    &.error--text {
+      background-color: map-get($red, "lighten4") !important;
+      border-color: map-get($red, "lighten3") !important;
+      color: map-get($red, "darken1") !important;
+    }
+  }
+}

--- a/preset/variables.scss
+++ b/preset/variables.scss
@@ -118,7 +118,7 @@ $headings: (
   )
 );
 
-$font-weights: (
+$fontWeights: (
   'regular': 400,
   'bold': 600,
 );
@@ -162,7 +162,7 @@ $material-light: (
   ),
   'dividers': map-get($grey, 'base'),
   'text': (
-    'primary': $text-primary-color
+    'primary': $textPrimaryColor
   ),
   'selection-controls': (
     'disabled': map-get($grey, 'lighten2'),

--- a/preset/variables.scss
+++ b/preset/variables.scss
@@ -118,7 +118,7 @@ $headings: (
   )
 );
 
-$fontWeights: (
+$font-weights: (
   'regular': 400,
   'bold': 600,
 );
@@ -162,7 +162,7 @@ $material-light: (
   ),
   'dividers': map-get($grey, 'base'),
   'text': (
-    'primary': $textPrimaryColor
+    'primary': $text-primary-color
   ),
   'selection-controls': (
     'disabled': map-get($grey, 'lighten2'),


### PR DESCRIPTION
Design on right, code on left:
![Screen Shot 2020-09-04 at 3 07 55 PM](https://user-images.githubusercontent.com/14173164/92195168-73abec80-eec0-11ea-9750-60400cbace22.png)

Use of important tags to combat this:
![Screen Shot 2020-09-04 at 3 06 40 PM](https://user-images.githubusercontent.com/14173164/92195199-7eff1800-eec0-11ea-8458-f494727b3b07.png)

Which seems to be coming from Vuetify and out of our hands?

<details>
<summary>
Code from example:
</summary>

```
<v-alert type="success" outlined>
  I'm a success <strong>alert</strong>.
</v-alert>

<v-alert type="info" outlined>
  I'm an info <strong>alert</strong>.
</v-alert>

<v-alert type="warning" outlined>
  I'm a warning <strong>alert</strong>.
</v-alert>

<v-alert type="error" outlined>
  I'm an error <strong>alert</strong>.
</v-alert>
```

</details>