### PR TITLE
Update clearable icons for inputs to be grey

### DIFF
--- a/preset/overrides.scss
+++ b/preset/overrides.scss
@@ -2,6 +2,7 @@
 @import "./expansion_panel_overrides";
 @import "./skeleton_overrides";
 @import "./v_alert_overrides";
+@import "./v_input_icon_overrides";
 
 .v-application--is-ltr {
   .v-list-group--sub-group {

--- a/preset/v_input_icon_overrides.scss
+++ b/preset/v_input_icon_overrides.scss
@@ -1,0 +1,5 @@
+.v-application {
+  .v-input__icon--clear > .v-icon--link {
+    color: map-get($grey, "darken1") !important;
+  }
+}


### PR DESCRIPTION
Clearable input icons should always be _grey_

So changes this:
<img width="654" alt="Storypark 2020-09-09 15-01-31" src="https://user-images.githubusercontent.com/1263717/92549457-653d4680-f2ad-11ea-9294-c0de6bddb797.png">

To this:
<img width="652" alt="Storypark 2020-09-09 14-56-37" src="https://user-images.githubusercontent.com/1263717/92549453-63738300-f2ad-11ea-9b2b-439e952a0600.png">
