### PR TITLE
Add a max-width to the span directly under v-btn

### DIFF
--- a/preset/overrides.scss
+++ b/preset/overrides.scss
@@ -1,8 +1,9 @@
-@import "./variables";
-@import "./expansion_panel_overrides";
-@import "./skeleton_overrides";
-@import "./v_alert_overrides";
-@import "./v_input_icon_overrides";
+@import './variables';
+@import './expansion_panel_overrides';
+@import './skeleton_overrides';
+@import './v_alert_overrides';
+@import './v_btn_overrides';
+@import './v_input_icon_overrides';
 
 .v-application--is-ltr {
   .v-list-group--sub-group {
@@ -38,7 +39,7 @@
 
     &--active {
       color: $text-primary-color;
-      font-weight: map-get($font-weights, "bold");
+      font-weight: map-get($font-weights, 'bold');
     }
   }
 }

--- a/preset/v_btn_overrides.scss
+++ b/preset/v_btn_overrides.scss
@@ -1,0 +1,7 @@
+.v-application {
+  .v-btn {
+    > span {
+      max-width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
Fixes this:
<img width="1009" alt="Screen_Shot_2020-08-25_at_11 30 59_AM" src="https://user-images.githubusercontent.com/14173164/93036433-f63c6500-f693-11ea-9915-21f1b15d971e.png">

Makes like:
<img width="977" alt="Screen Shot 2020-09-14 at 2 00 46 PM" src="https://user-images.githubusercontent.com/14173164/93036443-fe94a000-f693-11ea-95ac-f2046152e28a.png">
