### PR TITLE
Overriding the material-light text disabled variable to change the placeholder and disabled color to match the storypark grey

### DIFF
--- a/preset/variables.scss
+++ b/preset/variables.scss
@@ -163,7 +163,8 @@ $material-light: (
   ),
   'dividers': map-get($grey, 'base'),
   'text': (
-    'primary': $text-primary-color
+    'primary': $text-primary-color,
+    'disabled': map-get($grey, 'base'),
   ),
   'selection-controls': (
     'disabled': map-get($grey, 'lighten2'),


### PR DESCRIPTION
Currently we are using the default placeholder color and Andrew would like it to be the storypark grey base color. This change will also affect a number of disabled states which should also help us align closer to the pattern library