### PR TITLE
Make black actually black.

### DIFF
--- a/preset/spml.scss
+++ b/preset/spml.scss
@@ -22,7 +22,7 @@
 .wysiwyg-color-7 { color: #F26E62; }
 .wysiwyg-color-8 { color: #897657; }
 .wysiwyg-color-9 { color: #000000; }
-.wysiwyg-color-black { color: #30CB75; }
+.wysiwyg-color-black { color: #000000; }
 .wysiwyg-color-gray { color: #4E5A67; }
 .wysiwyg-color-red { color: #FF6E60; }
 .wysiwyg-color-green { color: #30CB75; }


### PR DESCRIPTION
In this PR in storyjar - https://github.com/storypark/storyjar/pull/4915, we moved the wysiwyg colors over there but I noticed that the black was not black.

I think this just changed accidentally over the years with merges and it went unnoticed.

https://github.com/storypark/storyjar/commit/aa49a9dd512848a844b0c8b5be448d20630485ca#diff-9ce0cac01856f4d30e5c75b232f2fadd27c72add679019c4308919e57e845a71R680

I think it should be black so have made this change for it.