### PR TITLE
Update v-tooltip line height globally

### DIFF
--- a/preset/component_overrides/_v_tooltip.scss
+++ b/preset/component_overrides/_v_tooltip.scss
@@ -1,0 +1,5 @@
+.v-tooltip {
+  &__content {
+    line-height: inherit;
+  }
+}

--- a/preset/overrides.scss
+++ b/preset/overrides.scss
@@ -6,3 +6,4 @@
 @import "./component_overrides/v_list";
 @import "./component_overrides/v_skeleton";
 @import "./component_overrides/v_tabs";
+@import "./component_overrides/v_tooltip";


### PR DESCRIPTION
For [SLOW-85](https://storypark.atlassian.net/browse/SLOW-85) we need to change the line height on tooltips to be consistent with the rest of the app.  I've added an override so they'll inherit from the cascade, in this case getting the 1.5 that is set on `.v-application`.