### PR TITLE
SLOW-87 Override the line height for textarea to be 1.5rem

### DIFF
--- a/preset/variables.scss
+++ b/preset/variables.scss
@@ -144,6 +144,9 @@ $dialog-border-radius: 8px;
 // v-input
 $input-label-letter-spacing: normal;
 
+// textarea
+$textarea-line-height: 1.5rem;
+
 // v-tab
 $body-1: map-get($headings, 'body-1');
 $tab-font-size: map-get($body-1, 'size');

--- a/preset/variables.scss
+++ b/preset/variables.scss
@@ -145,7 +145,7 @@ $dialog-border-radius: 8px;
 $input-label-letter-spacing: normal;
 
 // textarea
-$textarea-line-height: 1.5rem;
+$textarea-line-height: 1.5;
 
 // v-tab
 $body-1: map-get($headings, 'body-1');


### PR DESCRIPTION
For SLOW-87 we need to change the line-height for `textarea` to `1.5rem`. The default for Vuetify is `1.75rem`. As there was a sass variable for it, I have just changed that.