### PR TITLE
[SLOW-138] Change SPML typography

### DIFF
--- a/preset/spml.scss
+++ b/preset/spml.scss
@@ -6,11 +6,19 @@
 .wysiwyg-text-align-center { text-align: center; }
 .wysiwyg-text-align-right { text-align: right; }
 
-.wysiwyg-font-size-title { font-size: 28px; line-height: 34px; }
-.wysiwyg-font-size-x-large { font-size: 22px; line-height: 30px; }
-.wysiwyg-font-size-large { font-size: 20px; line-height: 28px; }
-.wysiwyg-font-size-medium { font-size: 17px; line-height: 24px; }
-.wysiwyg-font-size-small { font-size: 15px; line-height: 20px; }
+.wysiwyg-font-size-title { font-size: 48px; line-height: 56px; }
+.wysiwyg-font-size-x-large { font-size: 32px; line-height: 48px; }
+.wysiwyg-font-size-large { font-size: 24px; line-height: 32px; }
+.wysiwyg-font-size-medium { font-size: 20px; line-height: 32px; }
+.wysiwyg-font-size-small { font-size: 16px; line-height: 24px; }
+
+@media (max-width: 600px) {
+  .wysiwyg-font-size-title { font-size: 32px; line-height: 40px; }
+  .wysiwyg-font-size-x-large { font-size: 24px; line-height: 32px; }
+  .wysiwyg-font-size-large { font-size: 20px; line-height: 32px; }
+  .wysiwyg-font-size-medium { font-size: 16px; line-height: 24px; }
+  .wysiwyg-font-size-small { font-size: 14px; line-height: 24px; }
+}
 
 .wysiwyg-color-0 { color: #EA85B6; }
 .wysiwyg-color-1 { color: #7D7DBB; }

--- a/preset/spml.scss
+++ b/preset/spml.scss
@@ -12,7 +12,7 @@
 .wysiwyg-font-size-medium { font-size: 20px; line-height: 32px; }
 .wysiwyg-font-size-small { font-size: 16px; line-height: 24px; }
 
-@media (max-width: 600px) {
+@media only screen and (max-width: 600px) {
   .wysiwyg-font-size-title { font-size: 32px; line-height: 40px; }
   .wysiwyg-font-size-x-large { font-size: 24px; line-height: 32px; }
   .wysiwyg-font-size-large { font-size: 20px; line-height: 32px; }


### PR DESCRIPTION
Story: [in Jira](https://storypark.atlassian.net/browse/SLOW-138)
Designs: [in Figma](https://www.figma.com/file/k930lmXV6OwvwKGGw0L0xP/Story-editor-basics?node-id=61%3A0)

This story just changes the `font-size` and `line-height` values for all the `.wysiwyg-*` classes we use to style SPML blocks.  It also adds a mobile-responsive set of sizes.

At the moment the Education app has its own sizing for mobile titles so I'll make a separate small PR to remove that at the same time as I bump the preset version once this is merged :)

<img width="507" alt="Screen Shot 2021-04-20 at 1 45 18 PM" src="https://user-images.githubusercontent.com/39213/115324820-ad76fc80-a1de-11eb-9f7e-1af39b1acae5.png">
