### PR TITLE
Unset min-width on v-tabs

### DIFF
--- a/preset/variables.scss
+++ b/preset/variables.scss
@@ -152,6 +152,7 @@ $body-1: map-get($headings, 'body-1');
 $tab-font-size: map-get($body-1, 'size');
 $tab-font-weight: map-get($body-1, 'weight');
 $tabs-item-letter-spacing: normal;
+$tabs-item-min-width: unset;
 
 // v-list
 $list-dense-min-height: 24px;


### PR DESCRIPTION
Currently Vuetify has a default min-width on v-tabs, as 90px

![Screen Shot 2021-08-06 at 11 49 17 AM](https://user-images.githubusercontent.com/14173164/128435413-4cd86c94-4ce2-4f94-820e-51f75e3b44a6.png)

https://vuetifyjs.com/en/api/v-tabs/

Dave wants the horizontal padding decreased in the new sub nav, and this is what is making it seem strange.

Before:
![Screen Shot 2021-08-06 at 11 53 04 AM](https://user-images.githubusercontent.com/14173164/128435702-8a3ffc9d-be0c-43d2-9398-d2f630b72cc2.png)

After:
![Screen Shot 2021-08-06 at 11 50 09 AM](https://user-images.githubusercontent.com/14173164/128435711-22815a03-0e5e-4a2a-814d-9a1e54d38b84.png)

This has had Dave Keyes signify locally sharing screens